### PR TITLE
Change the API to compress and uncompress in place instead of allocating new arrays every time

### DIFF
--- a/src/main/java/com/ning/jcbm/ByteArrayOutputStream.java
+++ b/src/main/java/com/ning/jcbm/ByteArrayOutputStream.java
@@ -1,0 +1,42 @@
+package com.ning.jcbm;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * Same as {@link java.io.ByteArrayOutputStream} but allows to wrap an existing
+ * array.
+ */
+public class ByteArrayOutputStream extends OutputStream {
+
+    private final byte[] wrapped;
+    private int length;
+
+    public ByteArrayOutputStream(byte[] wrapped) {
+        if (wrapped == null) {
+            throw new IllegalArgumentException("Cannot wrap a nul array");
+        }
+        this.wrapped = wrapped;
+        this.length = 0;
+    }
+
+    public byte[] array() {
+        return wrapped;
+    }
+
+    public int length() {
+        return length;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+        wrapped[length++] = (byte) b;
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+        System.arraycopy(b, off, wrapped, length, len);
+        length += len;
+    }
+
+}

--- a/src/main/java/com/ning/jcbm/DriverBase.java
+++ b/src/main/java/com/ning/jcbm/DriverBase.java
@@ -1,12 +1,17 @@
 package com.ning.jcbm;
 
-import java.io.*;
+import java.io.ByteArrayInputStream;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Arrays;
 
+import com.ning.jcbm.util.DevNullOutputStream;
 import com.sun.japex.Constants;
 import com.sun.japex.JapexDriverBase;
 import com.sun.japex.TestCase;
-
-import com.ning.jcbm.util.*;
 
 /**
  */
@@ -65,9 +70,19 @@ public abstract class DriverBase extends JapexDriverBase
     protected byte[] _uncompressed;
 
     /**
+     * The buffer where to compress data.
+     */
+    protected byte[] _compressBuffer;
+
+    /**
      * Compressed test data
      */
     protected byte[] _compressed;
+
+    /**
+     * The buffer where to uncompress data.
+     */
+    protected byte[] _uncompressBuffer;
 
     protected DriverBase(String name)
     {
@@ -117,11 +132,16 @@ public abstract class DriverBase extends JapexDriverBase
         } else {
             throw new IllegalArgumentException("Invalid 'operation' part of name, '"+operStr+"': should start with 'C', 'U' or 'R'");
         }
-        _inputFile = new File(_inputDir, filename); 
+        _inputFile = new File(_inputDir, filename);
         try {
             // First things first: load uncompressed input in memory; compress to verify round-tripping
             _uncompressed = loadFile(_inputFile);
-            _compressed = compressBlock(_uncompressed);
+            _compressed = new byte[maxCompressedLength(_uncompressed.length)];
+            int compressedLen = compressBlock(_uncompressed, _compressed);
+            _compressed = Arrays.copyOf(_compressed, compressedLen);
+            _compressBuffer = new byte[maxCompressedLength(_uncompressed.length)];
+            // +1024 so that it can't be used by the driver to find the original length
+            _uncompressBuffer = new byte[_uncompressed.length + 1024];
             verifyRoundTrip(testCase.getName(), _uncompressed, _compressed);
         }
         catch (RuntimeException e) {
@@ -151,8 +171,7 @@ public abstract class DriverBase extends JapexDriverBase
                     out.close();
                     _totalLength = out.length();
                 } else {
-                    byte[] stuff = compressBlock(_uncompressed);
-                    _totalLength = stuff.length;
+                    _totalLength = compressBlock(_uncompressed, _compressBuffer);
                 }
                 break;
             case UNCOMPRESS:
@@ -161,8 +180,7 @@ public abstract class DriverBase extends JapexDriverBase
                     _totalLength = uncompressFromStream(in, _inputBuffer);
                     in.close();
                 } else {
-                    byte[] stuff = uncompressBlock(_compressed);
-                    _totalLength = stuff.length;
+                    _totalLength = uncompressBlock(_compressed, _uncompressBuffer);
                 }
                 break;
             default:
@@ -174,9 +192,8 @@ public abstract class DriverBase extends JapexDriverBase
                     _totalLength = uncompressFromStream(in, _inputBuffer);
                     in.close();
                 } else {
-                    byte[] stuff = compressBlock(_uncompressed);
-                    stuff = uncompressBlock(stuff);
-                    _totalLength = stuff.length;
+                    compressBlock(_uncompressed, _compressBuffer);
+                    _totalLength = uncompressBlock(_compressed, _uncompressBuffer);
                 }
             }
         } catch (Exception e) {
@@ -230,9 +247,16 @@ public abstract class DriverBase extends JapexDriverBase
     ///////////////////////////////////////////////////////////////////////
      */
 
-    protected abstract byte[] compressBlock(byte[] uncompressed) throws IOException;
+    protected int maxCompressedLength(int length) {
+        // Drivers that can compute the max compressed length should override
+        // this method
+        // Larg-ish default impl: 2*len + 1KB
+        return 2 * length + 1024;
+    }
 
-    protected abstract byte[] uncompressBlock(byte[] compressed) throws IOException;
+    protected abstract int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException;
+
+    protected abstract int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException;
 
     protected abstract void compressToStream(byte[] uncompressed, OutputStream out)
         throws IOException;
@@ -246,34 +270,35 @@ public abstract class DriverBase extends JapexDriverBase
     ///////////////////////////////////////////////////////////////////////
      */
 
-    protected byte[] compressBlockUsingStream(byte[] uncompressed) throws IOException
+    protected int compressBlockUsingStream(byte[] uncompressed, byte[] compressBuffer) throws IOException
     {
-        ByteArrayOutputStream out = new ByteArrayOutputStream(uncompressed.length);
+        ByteArrayOutputStream out = new ByteArrayOutputStream(compressBuffer);
         compressToStream(uncompressed, out);
-        return out.toByteArray();
+        return out.length();
     }
 
-    protected byte[] uncompressBlockUsingStream(InputStream in) throws IOException
+    protected int uncompressBlockUsingStream(InputStream in, byte[] uncompressBuffer) throws IOException
     {
-        ByteArrayOutputStream out = new ByteArrayOutputStream(_compressed.length);
-        byte[] buffer = new byte[4000];
+        ByteArrayOutputStream out = new ByteArrayOutputStream(uncompressBuffer);
+        byte[] buffer = new byte[4096];
         int count;
         while ((count = in.read(buffer)) >= 0) {
             out.write(buffer, 0, count);
         }
         in.close();
         out.close();
-        return out.toByteArray();
+        return out.length();
     }
     
     protected void verifyRoundTrip(String name, byte[] raw, byte[] compressed) throws IOException
     {
-        byte[] actual = uncompressBlock(compressed);
-        if (actual.length != raw.length) {
+        byte[] actual = new byte[raw.length + 1];
+        final int actualLength = uncompressBlock(compressed, actual);
+        if (actualLength != raw.length) {
             throw new IllegalArgumentException("Round-trip failed for driver '"+_driverName+"', input '"+name+"': uncompressed length was "+actual.length+" bytes; expected "+raw.length);
         }
         int i = 0;
-        for (int len = actual.length; i < len; ++i) {
+        for (int len = raw.length; i < len; ++i) {
             if (actual[i] != raw[i]) {
                 throw new IllegalArgumentException("Round-trip failed for driver '"+_driverName+"', input '"+name+"': bytes at offset "+i
                         +" (from total of "+len+") differed, expected 0x"+Integer.toHexString(raw[i] & 0xFF)
@@ -285,7 +310,7 @@ public abstract class DriverBase extends JapexDriverBase
     protected byte[] loadFile(File file) throws IOException
     {
         FileInputStream in = new FileInputStream(file);
-        ByteArrayOutputStream out = new ByteArrayOutputStream((int) file.length());
+        java.io.ByteArrayOutputStream out = new java.io.ByteArrayOutputStream((int) file.length());
         byte[] buffer = new byte[4000];
         int count;
         

--- a/src/main/java/com/ning/jcbm/bzip2/BZip2Driver.java
+++ b/src/main/java/com/ning/jcbm/bzip2/BZip2Driver.java
@@ -17,12 +17,12 @@ public class BZip2Driver  extends DriverBase
 
     // No native Block API; but need some impl for test framework
     
-    protected byte[] compressBlock(byte[] uncompressed) throws IOException {
-        return compressBlockUsingStream(uncompressed);
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException {
+        return compressBlockUsingStream(uncompressed, compressBuffer);
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException {
-        return uncompressBlockUsingStream(new BZip2CompressorInputStream(new ByteArrayInputStream(compressed)));
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException {
+        return uncompressBlockUsingStream(new BZip2CompressorInputStream(new ByteArrayInputStream(compressed)), uncompressBuffer);
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut) throws IOException

--- a/src/main/java/com/ning/jcbm/gzip/JCraftGzipDriver.java
+++ b/src/main/java/com/ning/jcbm/gzip/JCraftGzipDriver.java
@@ -21,12 +21,12 @@ public class JCraftGzipDriver extends DriverBase
 
     // No native Block API; but need some impl for test framework
     
-    protected byte[] compressBlock(byte[] uncompressed) throws IOException {
-        return compressBlockUsingStream(uncompressed);
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException {
+        return compressBlockUsingStream(uncompressed, compressBuffer);
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException {
-        return uncompressBlockUsingStream(new ZInputStream(new ByteArrayInputStream(compressed), NO_WRAP));
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException {
+        return uncompressBlockUsingStream(new ZInputStream(new ByteArrayInputStream(compressed), NO_WRAP), uncompressBuffer);
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut) throws IOException

--- a/src/main/java/com/ning/jcbm/gzip/JDKGzipDriver.java
+++ b/src/main/java/com/ning/jcbm/gzip/JDKGzipDriver.java
@@ -26,13 +26,13 @@ public class JDKGzipDriver extends DriverBase
     
     // No native Block API; but need some impl for test framework
     
-    protected byte[] compressBlock(byte[] uncompressed) throws IOException {
-        return compressBlockUsingStream(uncompressed);
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException {
+        return compressBlockUsingStream(uncompressed, compressBuffer);
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException {
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException {
         _inflater.reset();
-        return uncompressBlockUsingStream(new InflaterInputStream(new ByteArrayInputStream(compressed), _inflater));
+        return uncompressBlockUsingStream(new InflaterInputStream(new ByteArrayInputStream(compressed), _inflater), uncompressBuffer);
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut) throws IOException

--- a/src/main/java/com/ning/jcbm/iq80snappy/Iq80SnappyDriver.java
+++ b/src/main/java/com/ning/jcbm/iq80snappy/Iq80SnappyDriver.java
@@ -6,7 +6,6 @@ import org.iq80.snappy.Snappy;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.Arrays;
 
 /**
  * Driver for pure-Java Snappy codec from
@@ -19,19 +18,21 @@ public class Iq80SnappyDriver extends DriverBase
         super("iq80.Snappy");
     }
 
-    protected byte[] compressBlock(byte[] uncompressed)
-            throws IOException
-    {
-        byte[] compressed = new byte[Snappy.maxCompressedLength(uncompressed.length)];
-        int compressedSize = Snappy.compress(uncompressed, 0, uncompressed.length, compressed, 0);
-        return Arrays.copyOf(compressed, compressedSize);
+    @Override
+    protected int maxCompressedLength(int length) {
+        return Snappy.maxCompressedLength(length);
     }
 
-    protected byte[] uncompressBlock(byte[] compressed)
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer)
             throws IOException
     {
-        byte[] uncompressed = Snappy.uncompress(compressed, 0, compressed.length);
-        return uncompressed;
+        return Snappy.compress(uncompressed, 0, uncompressed.length, compressBuffer, 0);
+    }
+
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer)
+            throws IOException
+    {
+        return Snappy.uncompress(compressed, 0, compressed.length, uncompressBuffer, 0);
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut)

--- a/src/main/java/com/ning/jcbm/lz4/Lz4JNIDriver.java
+++ b/src/main/java/com/ning/jcbm/lz4/Lz4JNIDriver.java
@@ -18,15 +18,20 @@ public class Lz4JNIDriver extends DriverBase
         super("LZ4/JNI");
         _codec = new Lz4Compression();
     }
-    
-    protected byte[] compressBlock(byte[] src) throws IOException
-    {
-        return _codec.CompressSimple(src);
+
+    @Override
+    protected int maxCompressedLength(int length) {
+        return _codec.MaxCompressedSize(length);
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException
+    protected int compressBlock(byte[] src, byte[] compressBuffer) throws IOException
     {
-        return _codec.DecompressSimple(compressed);
+        return _codec.Compress(src, 0, src.length, compressBuffer, 0);
+    }
+
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException
+    {
+        return _codec.Decompress(compressed, 0, compressed.length, uncompressBuffer, 0);
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut)

--- a/src/main/java/com/ning/jcbm/lzf/LzfDriver.java
+++ b/src/main/java/com/ning/jcbm/lzf/LzfDriver.java
@@ -15,14 +15,17 @@ public class LzfDriver extends DriverBase
         super("LZF");
     }
 
-    protected byte[] compressBlock(byte[] uncompressed) throws IOException
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException
     {
-        return LZFEncoder.encode(uncompressed);
+        // TODO: compress in place?
+        byte[] compressed = LZFEncoder.encode(uncompressed);
+        System.arraycopy(compressed, 0, compressBuffer, 0, compressed.length);
+        return compressed.length;
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException
     {
-        return LZFDecoder.decode(compressed);
+        return LZFDecoder.decode(compressed, 0, compressed.length, uncompressBuffer);
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut)

--- a/src/main/java/com/ning/jcbm/lzma/LzmaJavaDriver.java
+++ b/src/main/java/com/ning/jcbm/lzma/LzmaJavaDriver.java
@@ -21,13 +21,13 @@ public class LzmaJavaDriver extends DriverBase
 
     // No native Block API; but need some impl for test framework
     
-    public byte[] compressBlock(byte[] uncompressed) throws IOException {
-        return compressBlockUsingStream(uncompressed);
+    public int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException {
+        return compressBlockUsingStream(uncompressed, compressBuffer);
     }
 
-    public byte[] uncompressBlock(byte[] compressed) throws IOException {
+    public int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException {
         return uncompressBlockUsingStream(
-                new LzmaInputStream(new ByteArrayInputStream(compressed), getDecoder()));
+                new LzmaInputStream(new ByteArrayInputStream(compressed), getDecoder()), uncompressBuffer);
     }
 
     public void compressToStream(byte[] uncompressed, OutputStream rawOut) throws IOException

--- a/src/main/java/com/ning/jcbm/quicklz/QuickLZDriverBase.java
+++ b/src/main/java/com/ning/jcbm/quicklz/QuickLZDriverBase.java
@@ -16,14 +16,18 @@ public class QuickLZDriverBase extends DriverBase
         _compressionLevel = level;
     }
 
-    protected byte[] compressBlock(byte[] uncompressed) throws IOException
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException
     {
-        return QuickLZ.compress(uncompressed, _compressionLevel);
+        byte[] compressed = QuickLZ.compress(uncompressed, _compressionLevel);
+        System.arraycopy(compressed, 0, compressBuffer, 0, compressed.length);
+        return compressed.length;
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException
     {
-        return QuickLZ.decompress(compressed);
+        byte[] decompressed = QuickLZ.decompress(compressed);
+        System.arraycopy(decompressed, 0, uncompressBuffer, 0, decompressed.length);
+        return decompressed.length;
     }
 
     /* Streaming operation not supported directly; let's not try faking it

--- a/src/main/java/com/ning/jcbm/snappy/SnappyDriver.java
+++ b/src/main/java/com/ning/jcbm/snappy/SnappyDriver.java
@@ -14,14 +14,19 @@ public class SnappyDriver extends DriverBase
         super("Snappy");
     }
 
-    protected byte[] compressBlock(byte[] uncompressed) throws IOException
-    {
-        return Snappy.compress(uncompressed);
+    @Override
+    protected int maxCompressedLength(int length) {
+        return Snappy.maxCompressedLength(length);
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException
     {
-        return Snappy.uncompress(compressed);
+        return Snappy.compress(uncompressed, 0, uncompressed.length, compressBuffer, 0);
+    }
+
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException
+    {
+        return Snappy.uncompress(compressed, 0, compressed.length, uncompressBuffer, 0);
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut) throws IOException

--- a/src/main/java/com/ning/jcbm/voldemort/VoldemortLZFDriver.java
+++ b/src/main/java/com/ning/jcbm/voldemort/VoldemortLZFDriver.java
@@ -13,14 +13,18 @@ public class VoldemortLZFDriver extends DriverBase
         super("LZF");
     }
 
-    protected byte[] compressBlock(byte[] uncompressed) throws IOException
+    protected int compressBlock(byte[] uncompressed, byte[] compressBuffer) throws IOException
     {
-        return VoldemortLZFEncoder.encode(uncompressed);
+        byte[] compressed = VoldemortLZFEncoder.encode(uncompressed);
+        System.arraycopy(compressed, 0, compressBuffer, 0, compressed.length);
+        return compressed.length;
     }
 
-    protected byte[] uncompressBlock(byte[] compressed) throws IOException
+    protected int uncompressBlock(byte[] compressed, byte[] uncompressBuffer) throws IOException
     {
-        return VoldemortLZFDecoder.decode(compressed);
+        byte[] decompressed = VoldemortLZFDecoder.decode(compressed);
+        System.arraycopy(decompressed, 0, uncompressBuffer, 0, decompressed.length);
+        return decompressed.length;
     }
 
     protected void compressToStream(byte[] uncompressed, OutputStream rawOut)


### PR DESCRIPTION
This way, the time to allocate new arrays won't count into the compression and uncompression time, which should be fairer to very fast impls such as LZ4, Snappy or LZF. Moreover it makes garbage collection less likely and tests more reproducible.

I couldn't find the API to compress in place with LZF, maybe you can help?
